### PR TITLE
INTG-1602 fix releaser

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,4 +107,3 @@ jobs:
           token: "${{ secrets.GITHUB_TOKEN }}"
           artifacts: "exporter*.zip,exporter*.tar.gz"
           allowUpdates: true
-          updateOnlyUnreleased: true


### PR DESCRIPTION
this PR replaces `marvinpinto/action-automatic-releases@latest` with `ncipollo/release-action@v1`.
The latter allows for updating a release if it already exists.