### PR TITLE
INTG-2655 config page status bar fix

### DIFF
--- a/frontend/src/components/StatusBar.svelte
+++ b/frontend/src/components/StatusBar.svelte
@@ -33,12 +33,15 @@
 
 <style>
     .bar {
+        position: absolute;
         padding: 5px 10px;
         background-color: #675DF4;
         color: whitesmoke;
         display: flex;
         justify-content: space-between;
         height: auto;
+        width: 100%;
+        bottom: 0;
     }
 
     .latest {

--- a/frontend/src/routes/Config.svelte
+++ b/frontend/src/routes/Config.svelte
@@ -519,7 +519,7 @@
 
 	.export-details {
 		width: 380px;
-		height: 610px;
+		height: 590px;
 		background-color: #E9EEF6;
 		padding: 16px;
 		overflow-y: auto;


### PR DESCRIPTION
Status bar is cut off on the config page in the Windows build. PR to fix this issue